### PR TITLE
Update API to handle multiple pages of subscriptions.

### DIFF
--- a/src/SaaS.SDK.Client/Helpers/UrlHelper.cs
+++ b/src/SaaS.SDK.Client/Helpers/UrlHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Marketplace.SaasKit.Helpers
                 case SaaSResourceActionEnum.OPERATION_STATUS:
                     return $"{clientConfiguration.FulFillmentAPIBaseURL}{subscriptionBaseURL}{resourceId}/operations/{operationId}?api-version={clientConfiguration.FulFillmentAPIVersion}";
                 case SaaSResourceActionEnum.ALL_SUBSCRIPTIONS:
-                    return $"{clientConfiguration.FulFillmentAPIBaseURL}?api-version={clientConfiguration.FulFillmentAPIVersion}";
+                    return $"{clientConfiguration.FulFillmentAPIBaseURL}{subscriptionBaseURL}?api-version={clientConfiguration.FulFillmentAPIVersion}";
                 case SaaSResourceActionEnum.SUBSCRIPTION_USAGEEVENT:
                     return $"{clientConfiguration.FulFillmentAPIBaseURL}/usageEvent?api-version={clientConfiguration.FulFillmentAPIVersion}";
                 default:

--- a/src/SaaS.SDK.Client/Models/SubscriptionListResult.cs
+++ b/src/SaaS.SDK.Client/Models/SubscriptionListResult.cs
@@ -20,5 +20,17 @@
         [JsonProperty("Subscriptions")]
         [DisplayName("Subscriptions")]
         public List<SubscriptionResult> SubscriptionsResult { get; set; }
+
+        /// <summary>
+        /// Indicates the URL for retrieving more subscriptions.
+        /// </summary>
+        /// <value>
+        /// This value will be null when no further subscriptions can be retrieved.
+        /// This value will contain a URL for subsequent queries when most subscriptions
+        /// exist to be retrieved.
+        /// </value>
+        [JsonProperty("@nextLink")]
+        [DisplayName("NextLink")]
+        public string NextLink { get; set; }
     }
 }

--- a/src/SaaS.SDK.Client/Services/FulfillmentApiClient.cs
+++ b/src/SaaS.SDK.Client/Services/FulfillmentApiClient.cs
@@ -51,8 +51,16 @@
             this.Logger?.Info($"Inside GetAllSubscriptionAsync() of FulfillmentApiClient, trying to get All Subscriptions.");
             var restClient = new FulfillmentApiRestClient<SubscriptionListResult>(this.ClientConfiguration, this.Logger);
             var url = UrlHelper.GetSaaSApiUrl(this.ClientConfiguration, default, SaaSResourceActionEnum.ALL_SUBSCRIPTIONS, null);
-            var subscriptResult = await restClient.DoRequest(url, HttpMethods.GET, null).ConfigureAwait(false);
-            return subscriptResult.SubscriptionsResult;
+            var subscriptionResult = await restClient.DoRequest(url, HttpMethods.GET, null).ConfigureAwait(false);
+            var retval = new List<SubscriptionResult>(subscriptionResult.SubscriptionsResult);
+
+            while (!string.IsNullOrEmpty(subscriptionResult.NextLink))
+            {
+                subscriptionResult = await restClient.DoRequest(subscriptionResult.NextLink, HttpMethods.GET, null).ConfigureAwait(false);
+                retval.AddRange(subscriptionResult.SubscriptionsResult);
+            }
+
+            return retval;
         }
 
         /// <summary>

--- a/src/SaaS.SDK.UnitTest/appsettings.test.json
+++ b/src/SaaS.SDK.UnitTest/appsettings.test.json
@@ -11,7 +11,7 @@
     "ClientId": "",
     "ClientSecret": "",
     "Resource": "",
-    "FulFillmentAPIBaseURL": "https://marketplaceapi.microsoft.com/api/saas/subscriptions/",
+    "FulFillmentAPIBaseURL": "https://marketplaceapi.microsoft.com/api",
     "FulFillmentAPIMeteringBaseURL": "https://marketplaceapi.microsoft.com/api/",
     "SignedOutRedirectUri": "",
     "TenantId": "",


### PR DESCRIPTION
This update handles paging on Subscriptions. One requires paging when the number of subscriptions on a given Commercial Marketplace account exceeds 85 across all offers. 

This issue also identified a problem with URL construction for the all subscriptions path. The default FulFillmentAPIBaseURL in the test was changed to point to the "right" URL. 