### PR TITLE
Deployment SQL Scripts

### DIFF
--- a/deployment/Database/AMP-DB-2.0.sql
+++ b/deployment/Database/AMP-DB-2.0.sql
@@ -487,9 +487,6 @@ BEGIN
 END
 GO
 
-ALTER TABLE Subscriptions ADD AMPQuantity INT
-
-GO
 Update Subscriptions set AMPQuantity = 0
 
 GO

--- a/deployment/Database/README.md
+++ b/deployment/Database/README.md
@@ -4,6 +4,14 @@
 
 The Provisioning and the Publisher applications use SQL Server database as the data source to store subscriptions and the status, metered dimensions by plans and activity against subscriptions.
 
+### Install Using SQL Scripts
+
+The SQL scripts build on top of each other. When setting up your database, do the following.
+ 
+ 1. Start with a blank database
+ 2. Run AMP-DB-1.0.sql
+ 3. Run AMP-DB-2.0.sql
+
 
 ### Description 
 

--- a/src/SaaS.SDK.CustomerProvisioning/Views/Home/SubscriptionQuantityDetail.cshtml
+++ b/src/SaaS.SDK.CustomerProvisioning/Views/Home/SubscriptionQuantityDetail.cshtml
@@ -52,6 +52,7 @@
                     <div class="text-right">
                         <button type="button" onclick="confirmQuantityDialog()" class="cm-button-default mt40 mr20 text-right">Change Quantity</button>
                     </div>
+                </div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
1. Removed a single alter table line that was redundant and causing an error report during install even though it was harmless.

2. Added install notes to README directing the deployment to use script 1.0 followed by adding script 2.0

3. Added a missing close div.