### PR TITLE
fix update subscription status on IsAutomaticProvisioningSupported

### DIFF
--- a/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
@@ -375,7 +375,7 @@
                         try
                         {
                             this.logger.LogInformation("operation == Activate");
-                            if (Convert.ToBoolean(applicationConfigRepository.GetValuefromApplicationConfig("IsAutomaticProvisioningSupported")))
+                            if (!Convert.ToBoolean(applicationConfigRepository.GetValuefromApplicationConfig("IsAutomaticProvisioningSupported")))
                             {
                                 this.logger.LogInformation("UpdateStateOfSubscription PendingActivation: SubscriptionId: {0} ", subscriptionId);
                                 this.subscriptionService.UpdateStateOfSubscription(subscriptionId, SubscriptionStatusEnum.PendingActivation, true);


### PR DESCRIPTION
when IsAutomaticProvisioningSupported is true , subscirption status should be Subscribed.
when IsAutomaticProvisioningSupported is false , subscirption status should be PendingActivation and Partner should activate the subscription.
Looks like the logic is a little wrong in the current code. 
Please correct me if my understanding is wrong on the Appconfig setting.