### PR TITLE
Quantity fix

### DIFF
--- a/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
@@ -139,7 +139,6 @@
                             this.subscriptionService.AddPlanDetailsForSubscription(subscriptionPlanDetail);
                             // GetSubscriptionBy SubscriptionId
                             var subscriptionData = this.apiClient.GetSubscriptionByIdAsync(newSubscription.SubscriptionId).ConfigureAwait(false).GetAwaiter().GetResult();
-                            subscriptionData.Quantity = 0;
                             var subscribeId = this.subscriptionService.AddUpdatePartnerSubscriptions(subscriptionData);
                             if (subscribeId > 0 && subscriptionData.SaasSubscriptionStatus == SubscriptionStatusEnum.PendingFulfillmentStart)
                             {

--- a/src/SaaS.SDK.CustomerProvisioning/Views/Home/Index.cshtml
+++ b/src/SaaS.SDK.CustomerProvisioning/Views/Home/Index.cshtml
@@ -59,7 +59,7 @@
                         <dd class="col-sm-9 p-2 p10">
                             @Html.DisplayFor(model => model.PlanId)
                         </dd>
-                        @if (Model.IsPerUserPlan)
+                        @if (Model.Quantity>0)
                         {
                             <dt class="col-sm-3 p-2 p10">
                                 @Html.DisplayName("Quantity ")

--- a/src/SaaS.SDK.CustomerProvisioning/Views/Home/Index.cshtml
+++ b/src/SaaS.SDK.CustomerProvisioning/Views/Home/Index.cshtml
@@ -59,7 +59,7 @@
                         <dd class="col-sm-9 p-2 p10">
                             @Html.DisplayFor(model => model.PlanId)
                         </dd>
-                        @if (Model.Quantity>0)
+                        @if (Model.IsPerUserPlan)
                         {
                             <dt class="col-sm-3 p-2 p10">
                                 @Html.DisplayName("Quantity ")


### PR DESCRIPTION
When customer comes to the landing page - removed quantity value from subscription api is being reset to 0. For peruser plans, they always come with a quantity >0 and the remaining it is serialized to zero anyway.