### PR TITLE
Fulfilment App Registrations should be Single Tenant

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -194,7 +194,7 @@ $ISADMTApplicationIDProvided = $ADMTApplicationID
 if (!($ADApplicationID)) {   
     Write-Host "🔑 Creating Fulfilment API App Registration"
     try {   
-        $ADApplication = az ad app create --only-show-errors --display-name "$WebAppNamePrefix-FulfillmentAppReg" | ConvertFrom-Json
+        $ADApplication = az ad app create --only-show-errors --sign-in-audience AzureADMYOrg --display-name "$WebAppNamePrefix-FulfillmentAppReg" | ConvertFrom-Json
 		$ADObjectID = $ADApplication.id
         $ADApplicationID = $ADApplication.appId
         sleep 5 #this is to give time to AAD to register


### PR DESCRIPTION
as per the requirements in the [documentation](https://learn.microsoft.com/en-us/partner-center/marketplace/partner-center-portal/pc-saas-registration#register-a-microsoft-entra-id-secured-app):

>You must register one app that accesses the API only, and as **single tenant**.