### PR TITLE
Updated the install instructions to 8.1.0

### DIFF
--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -39,7 +39,7 @@ chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 8.0.303; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
 dotnet tool install --global dotnet-ef --version 8.0.0; `
-git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 8.0.0 --depth 1; `
+git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 8.1.0 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Deploy.ps1 `
  -WebAppNamePrefix "SOME-UNIQUE-STRING" `


### PR DESCRIPTION
This pull request updates the installation instructions in the `docs/Installation-Instructions.md` file to reflect the latest version of the repository being cloned.

Version update in installation instructions:

* Updated the `git clone` command to clone the `8.1.0` branch of the `Commercial-Marketplace-SaaS-Accelerator` repository instead of the `8.0.0` branch.