### PR TITLE
Bugfix: Update SQL Server command to use Az module

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -211,7 +211,7 @@ Write-Host "Starting SaaS Accelerator Deployment..."
 
 
 #region Check If SQL Server Exist
-$sql_exists = Get-AzureRmSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
+$sql_exists = Get-AzSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
 if ($sql_exists) 
 {
 	Write-Host ""


### PR DESCRIPTION
Changes the reference to the Azure SQL Server commandled from `Get-AzureRmSqlServer` to `Get-AzSqlServer` to be compatible with the current release of the Azure PowerShell module.