### PR TITLE
fix(docs): replace ADMTApplicationID with ADMTApplicationIDPortal in documentation

### DIFF
--- a/docs/Advanced-Instructions.md
+++ b/docs/Advanced-Instructions.md
@@ -81,7 +81,7 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 | AzureSubscriptionID | Id of subscription where the resources will be deployed. Subscription must be part of the Tenant Provided. If value not provided, you will be asked to select the subscription during deployment. |
 | ADApplicationID | The value should match the value provided for Active Directory Application ID in the Technical Configuration of the Transactable Offer in Partner Center. If value not provided, a new application will be created. |
 | ADApplicationSecret | Valid secret for the ADApplication. Required if ADApplicationID is provided. If `ADApplicationID` is not provided, a secret will be generated. |
-| ADMTApplicationID | A valid App Id for an Azure AD Application configured for SSO login. If value not provided, a new application will be created. |
+| ADMTApplicationIDPortal | A valid App Id for an Azure AD Application configured for SSO login. If value not provided, a new application will be created. |
 | SQLServerName | A unique name of the database server (without database.windows.net). Default: `WebAppNamePrefix`-sql |
 | LogoURLpng | The url of the company logo image in .png format with a size of 96x96 to be used on the website |
 | LogoURLico | The url of the company logo image in .ico format |
@@ -96,7 +96,7 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
     -TenantID "tenandId" `
     -ADApplicationID "single-tenant clientId" `
     -ADApplicationSecret "single-tenant secret" `
-    -ADMTApplicationID "multi-tenant clientId" `
+    -ADMTApplicationIDPortal "multi-tenant clientId" `
     -PublisherAdminUsers "user@contoso.com" `              
     -AzureSubscriptionID "subscriptionId" `
     -ResourceGroupForDeployment "resourcegroup" `

--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -64,7 +64,7 @@ The script above will perform the following actions.
  -AzureSubscriptionID "xxx-xx-xx-xx-xxxx" `
  -ADApplicationID "xxxx-xxx-xxx-xxx-xxxx" `
  -ADApplicationSecret "xxxx-xxx-xxx-xxx-xxxx" `
- -ADMTApplicationID "xxxx-xxx-xxx-xxx-xxxx" `
+ -ADMTApplicationIDPortal "xxxx-xxx-xxx-xxx-xxxx" `
  -LogoURLpng "https://company_com/company_logo.png" `
  -LogoURLico "https://company_com/company_logo.ico" `
  -IsAdminPortalMultiTenant "true" `
@@ -105,7 +105,7 @@ cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 | AzureSubscriptionID | Id of subscription where the resources will be deployed. Subscription must be part of the Tenant Provided. If value not provided, you will be asked to select the subscription during deployment. |
 | ADApplicationID | The value should match the value provided for Active Directory Application ID in the Technical Configuration of the Transactable Offer in Partner Center. If value not provided, a new application will be created. |
 | ADApplicationSecret | Valid secret for the ADApplication. Required if ADApplicationID is provided. If `ADApplicationID` is not provided, a secret will be generated. |
-| ADMTApplicationID | A valid App Id for an Azure AD Application configured for SSO login. If value not provided, a new application will be created. |
+| ADMTApplicationIDPortal | A valid App Id for an Azure AD Application configured for SSO login. If value not provided, a new application will be created. |
 | SQLServerName | A unique name of the database server (without database.windows.net). Default: `WebAppNamePrefix`-sql |
 | LogoURLpng | The url of the company logo image in .png format with a size of 96x96 to be used on the website |
 | LogoURLico | The url of the company logo image in .ico format |


### PR DESCRIPTION
This pull request updates documentation to consistently rename the parameter for the Azure AD Application used for SSO login from `ADMTApplicationID` to `ADMTApplicationIDPortal`. This change ensures clarity and consistency across all setup and configuration instructions.

Documentation updates for parameter renaming:

* Renamed all references of the SSO login parameter from `ADMTApplicationID` to `ADMTApplicationIDPortal` in the parameter tables and example commands in `docs/Advanced-Instructions.md` and `docs/Installation-Instructions.md`. [[1]](diffhunk://#diff-7e450e8de5790333086d9f8e457161562a84f0e7fbbb48b076f37c003866bc77L84-R84) [[2]](diffhunk://#diff-7e450e8de5790333086d9f8e457161562a84f0e7fbbb48b076f37c003866bc77L99-R99) [[3]](diffhunk://#diff-7fde675f58b920435dbbb78464bb397a57debb6b138a2c29296550b0374c1a5cL67-R67) [[4]](diffhunk://#diff-7fde675f58b920435dbbb78464bb397a57debb6b138a2c29296550b0374c1a5cL108-R108)