### PR TITLE
Fix the install and deploy instructions

### DIFF
--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -81,7 +81,7 @@ If you already have deployed the SaaS Accelerator, but you want to update it so 
 *if upgrading to release version < 8.0.0, please replace the below dotnet and dotnet-ef versions to 6 release.
 
 ``` powershell
-wget https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh; `
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 8.0.303; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `

--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -34,7 +34,7 @@ Copy the following section to an editor and update it to match your company pref
 - [Optional] Replace `East US` with a region closest to you.
 
 ``` powershell
-wget https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh; `
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 8.0.303; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `


### PR DESCRIPTION
This pull request updates the installation instructions in `docs/Installation-Instructions.md` to use the new official download URL for the .NET installation script. The changes ensure that the script is downloaded using the latest recommended method and is saved with a specific filename.

Installation script improvements:

* Updated the `wget` command to use `https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh` instead of the previous URL, ensuring the script is downloaded from the current official source and saved as `dotnet-install.sh`. [[1]](diffhunk://#diff-7fde675f58b920435dbbb78464bb397a57debb6b138a2c29296550b0374c1a5cL37-R37) [[2]](diffhunk://#diff-7fde675f58b920435dbbb78464bb397a57debb6b138a2c29296550b0374c1a5cL84-R84)